### PR TITLE
Modules no functors

### DIFF
--- a/src/.#Fission.re
+++ b/src/.#Fission.re
@@ -1,0 +1,1 @@
+expede@Latte.local.56756

--- a/src/.#Fission.re
+++ b/src/.#Fission.re
@@ -1,1 +1,0 @@
-expede@Latte.local.56756

--- a/src/Fission.bs.js
+++ b/src/Fission.bs.js
@@ -63,7 +63,7 @@ function addStr(auth, _str) {
 }
 
 function pin(auth, cid) {
-  return handle(Axios$1.put(url(baseURL, cid), ({}), blankConfig(auth)));
+  return handle(Axios$1.put(url(baseURL, cid), { }, blankConfig(auth)));
 }
 
 function remove(auth, cid) {

--- a/src/Fission.bs.js
+++ b/src/Fission.bs.js
@@ -6,9 +6,21 @@ var Axios$1 = require("axios");
 
 var baseURL = "http://localhost:1337";
 
-var octetHeader = Axios.$$Headers[/* fromObj */0]({
-      "content-type": "application/octet-stream"
-    });
+var ipfsURL = "http://localhost:1337/ipfs";
+
+var cidsURL = "http://localhost:1337/ipfs/cids";
+
+function url(domain, cid) {
+  return domain + ("/ipfs/" + cid);
+}
+
+function handle(a) {
+  return a.then((function (response) {
+                  return Promise.resolve(response.data);
+                })).catch((function (prim) {
+                return Promise.resolve(prim);
+              }));
+}
 
 function convAuth(auth) {
   return {
@@ -17,68 +29,45 @@ function convAuth(auth) {
         };
 }
 
-function url(baseURL, cid) {
-  return baseURL + ("/ipfs/" + cid);
+var octetHeader = Axios.$$Headers[/* fromObj */0]({
+      "content-type": "application/octet-stream"
+    });
+
+function octetConfig(auth) {
+  return {
+          headers: octetHeader,
+          auth: convAuth(auth)
+        };
+}
+
+function blankConfig(auth) {
+  return {
+          auth: convAuth(auth)
+        };
 }
 
 function content(cid) {
-  return Axios$1.get(url(baseURL, cid)).then((function (response) {
-                  return Promise.resolve(response.data);
-                })).catch((function (error) {
-                return Promise.resolve(error);
-              }));
+  return handle(Axios$1.get(url(baseURL, cid)));
 }
 
 function list(auth) {
-  return Axios$1.get("http://localhost:1337/ipfs/cids", {
-                  auth: convAuth(auth)
-                }).then((function (response) {
-                  return Promise.resolve(response.data);
-                })).catch((function (error) {
-                return Promise.resolve(error);
-              }));
+  return handle(Axios$1.get(cidsURL, blankConfig(auth)));
 }
 
 function add(auth, content) {
-  return Axios$1.post("http://localhost:1337/ipfs/", content, {
-                  headers: octetHeader,
-                  auth: convAuth(auth)
-                }).then((function (response) {
-                  return Promise.resolve(response.data);
-                })).catch((function (error) {
-                return Promise.resolve(error);
-              }));
+  return handle(Axios$1.post(ipfsURL, content, octetConfig(auth)));
 }
 
 function addStr(auth, _str) {
-  return Axios$1.post("http://localhost:1337/ipfs/", str, {
-                  headers: octetHeader,
-                  auth: convAuth(auth)
-                }).then((function (response) {
-                  return Promise.resolve(response.data);
-                })).catch((function (error) {
-                return Promise.resolve(error);
-              }));
+  return handle(Axios$1.post(ipfsURL, str, octetConfig(auth)));
 }
 
 function pin(auth, cid) {
-  return Axios$1.put(url(baseURL, cid), ({}), {
-                  auth: convAuth(auth)
-                }).then((function (response) {
-                  return Promise.resolve(response.data);
-                })).catch((function (error) {
-                return Promise.resolve(error);
-              }));
+  return handle(Axios$1.put(url(baseURL, cid), ({}), blankConfig(auth)));
 }
 
 function remove(auth, cid) {
-  return Axios$1.delete(url(baseURL, cid), {
-                  auth: convAuth(auth)
-                }).then((function (response) {
-                  return Promise.resolve(response.data);
-                })).catch((function (error) {
-                return Promise.resolve(error);
-              }));
+  return handle(Axios$1.delete(url(baseURL, cid), blankConfig(auth)));
 }
 
 function fissionUser(base, username, password) {
@@ -87,22 +76,22 @@ function fissionUser(base, username, password) {
     /* password */password
   ];
   return /* record */[
-          /* base */base,
-          /* content */content,
-          /* url */(function (param) {
-              return url(base, param);
-            }),
           /* add */(function (param) {
               return add(user, param);
             }),
           /* addStr */(function (param) {
               return addStr(user, param);
             }),
+          /* base */base,
+          /* content */content,
           /* pin */(function (param) {
               return pin(user, param);
             }),
           /* remove */(function (param) {
               return remove(user, param);
+            }),
+          /* url */(function (param) {
+              return url(base, param);
             })
         ];
 }
@@ -111,11 +100,11 @@ function fission(base) {
   return /* record */[
           /* base */base,
           /* content */content,
-          /* url */(function (param) {
-              return url(base, param);
-            }),
           /* login */(function (param, param$1) {
               return fissionUser(base, param, param$1);
+            }),
+          /* url */(function (param) {
+              return url(base, param);
             })
         ];
 }
@@ -127,11 +116,16 @@ var env_username = "ca2c70bc13298c5109ee";
 var env_password = "VlBgonAFjZon2wd2VkTR3uc*p-XMd(L_Zf$nFvACpHQShqJ_Hp2Pa";
 
 exports.baseURL = baseURL;
+exports.ipfsURL = ipfsURL;
+exports.cidsURL = cidsURL;
+exports.url = url;
 exports.env_username = env_username;
 exports.env_password = env_password;
-exports.octetHeader = octetHeader;
+exports.handle = handle;
 exports.convAuth = convAuth;
-exports.url = url;
+exports.octetHeader = octetHeader;
+exports.octetConfig = octetConfig;
+exports.blankConfig = blankConfig;
 exports.content = content;
 exports.list = list;
 exports.add = add;

--- a/src/Fission.bs.js
+++ b/src/Fission.bs.js
@@ -6,10 +6,6 @@ var Axios$1 = require("axios");
 
 var baseURL = "http://localhost:1337";
 
-var env_username = "ca2c70bc13298c5109ee";
-
-var env_password = "VlBgonAFjZon2wd2VkTR3uc*p-XMd(L_Zf$nFvACpHQShqJ_Hp2Pa";
-
 var octetHeader = Axios.$$Headers[/* fromObj */0]({
       "content-type": "application/octet-stream"
     });
@@ -43,7 +39,7 @@ function list(auth) {
               }));
 }
 
-function add(content, auth) {
+function add(auth, content) {
   return Axios$1.post("http://localhost:1337/ipfs/", content, {
                   headers: octetHeader,
                   auth: convAuth(auth)
@@ -54,7 +50,7 @@ function add(content, auth) {
               }));
 }
 
-function addStr(_str, auth) {
+function addStr(auth, _str) {
   return Axios$1.post("http://localhost:1337/ipfs/", str, {
                   headers: octetHeader,
                   auth: convAuth(auth)
@@ -65,7 +61,7 @@ function addStr(_str, auth) {
               }));
 }
 
-function pin(cid, auth) {
+function pin(auth, cid) {
   return Axios$1.put(url(baseURL, cid), ({}), {
                   auth: convAuth(auth)
                 }).then((function (response) {
@@ -75,7 +71,7 @@ function pin(cid, auth) {
               }));
 }
 
-function remove(cid, auth) {
+function remove(auth, cid) {
   return Axios$1.delete(url(baseURL, cid), {
                   auth: convAuth(auth)
                 }).then((function (response) {
@@ -85,34 +81,48 @@ function remove(cid, auth) {
               }));
 }
 
-var user = /* record */[
-  /* username */env_username,
-  /* password */env_password
-];
-
-remove("QmQbPPkak9itW3v8WSohtonCBiJcrnAUhrSW1TGPnmWe3f", user).then((function (result) {
-          return Promise.resolve((console.log(result), /* () */0));
-        })).catch((function (error) {
-        return Promise.resolve((console.log(error), /* () */0));
-      }));
-
-function fission(base, auth) {
+function fissionUser(base, username, password) {
+  var user = /* record */[
+    /* username */username,
+    /* password */password
+  ];
   return /* record */[
           /* base */base,
           /* content */content,
           /* url */(function (param) {
               return url(base, param);
             }),
-          /* pin */(function (cid) {
-              return pin(cid, auth);
+          /* add */(function (param) {
+              return add(user, param);
+            }),
+          /* addStr */(function (param) {
+              return addStr(user, param);
+            }),
+          /* pin */(function (param) {
+              return pin(user, param);
+            }),
+          /* remove */(function (param) {
+              return remove(user, param);
             })
         ];
 }
 
-var me = /* record */[
-  /* age */5,
-  /* name */"Big Reason"
-];
+function fission(base) {
+  return /* record */[
+          /* base */base,
+          /* content */content,
+          /* url */(function (param) {
+              return url(base, param);
+            }),
+          /* login */(function (param, param$1) {
+              return fissionUser(base, param, param$1);
+            })
+        ];
+}
+
+var env_username = "ca2c70bc13298c5109ee";
+
+var env_password = "VlBgonAFjZon2wd2VkTR3uc*p-XMd(L_Zf$nFvACpHQShqJ_Hp2Pa";
 
 exports.baseURL = baseURL;
 exports.env_username = env_username;
@@ -126,7 +136,6 @@ exports.add = add;
 exports.addStr = addStr;
 exports.pin = pin;
 exports.remove = remove;
-exports.user = user;
-exports.me = me;
+exports.fissionUser = fissionUser;
 exports.fission = fission;
 /* octetHeader Not a pure module */

--- a/src/Fission.bs.js
+++ b/src/Fission.bs.js
@@ -10,10 +10,6 @@ var ipfsURL = "http://localhost:1337/ipfs";
 
 var cidsURL = "http://localhost:1337/ipfs/cids";
 
-function url(domain, cid) {
-  return domain + ("/ipfs/" + cid);
-}
-
 function convAuth(auth) {
   return {
           username: auth[/* username */0],
@@ -21,12 +17,16 @@ function convAuth(auth) {
         };
 }
 
-function handle(a) {
-  return a.then((function (response) {
+function $$await(promise) {
+  return promise.then((function (response) {
                   return Promise.resolve(response.data);
                 })).catch((function (prim) {
                 return Promise.resolve(prim);
               }));
+}
+
+function url(domain, cid) {
+  return domain + ("/ipfs/" + cid);
 }
 
 var octetHeader = Axios.$$Headers[/* fromObj */0]({
@@ -47,27 +47,27 @@ function blankConfig(auth) {
 }
 
 function content(cid) {
-  return handle(Axios$1.get(url(baseURL, cid)));
+  return $$await(Axios$1.get(url(baseURL, cid)));
 }
 
 function list(auth) {
-  return handle(Axios$1.get(cidsURL, blankConfig(auth)));
+  return $$await(Axios$1.get(cidsURL, blankConfig(auth)));
 }
 
 function add(auth, content) {
-  return handle(Axios$1.post(ipfsURL, content, octetConfig(auth)));
+  return $$await(Axios$1.post(ipfsURL, content, octetConfig(auth)));
 }
 
 function addStr(auth, _str) {
-  return handle(Axios$1.post(ipfsURL, str, octetConfig(auth)));
+  return $$await(Axios$1.post(ipfsURL, str, octetConfig(auth)));
 }
 
 function pin(auth, cid) {
-  return handle(Axios$1.put(url(baseURL, cid), { }, blankConfig(auth)));
+  return $$await(Axios$1.put(url(baseURL, cid), { }, blankConfig(auth)));
 }
 
 function remove(auth, cid) {
-  return handle(Axios$1.delete(url(baseURL, cid), blankConfig(auth)));
+  return $$await(Axios$1.delete(url(baseURL, cid), blankConfig(auth)));
 }
 
 function fissionUser(base, username, password) {
@@ -76,13 +76,13 @@ function fissionUser(base, username, password) {
     /* password */password
   ];
   return /* record */[
+          /* base */base,
           /* add */(function (param) {
               return add(user, param);
             }),
           /* addStr */(function (param) {
               return addStr(user, param);
             }),
-          /* base */base,
           /* content */content,
           /* pin */(function (param) {
               return pin(user, param);
@@ -99,10 +99,10 @@ function fissionUser(base, username, password) {
 function fission(base) {
   return /* record */[
           /* base */base,
-          /* content */content,
           /* login */(function (param, param$1) {
               return fissionUser(base, param, param$1);
             }),
+          /* content */content,
           /* url */(function (param) {
               return url(base, param);
             })
@@ -120,9 +120,9 @@ exports.ipfsURL = ipfsURL;
 exports.cidsURL = cidsURL;
 exports.env_username = env_username;
 exports.env_password = env_password;
-exports.url = url;
 exports.convAuth = convAuth;
-exports.handle = handle;
+exports.$$await = $$await;
+exports.url = url;
 exports.octetHeader = octetHeader;
 exports.octetConfig = octetConfig;
 exports.blankConfig = blankConfig;

--- a/src/Fission.bs.js
+++ b/src/Fission.bs.js
@@ -4,19 +4,6 @@
 var Axios = require("bs-axios/src/axios.js");
 var Axios$1 = require("axios");
 
-var baseURL = "http://localhost:1337";
-
-var ipfsURL = "http://localhost:1337/ipfs";
-
-var cidsURL = "http://localhost:1337/ipfs/cids";
-
-function convAuth(auth) {
-  return {
-          username: auth[/* username */0],
-          password: auth[/* password */1]
-        };
-}
-
 function $$await(promise) {
   return promise.then((function (response) {
                   return Promise.resolve(response.data);
@@ -25,8 +12,11 @@ function $$await(promise) {
               }));
 }
 
-function url(domain, cid) {
-  return domain + ("/ipfs/" + cid);
+function convAuth(auth) {
+  return {
+          username: auth[/* username */0],
+          password: auth[/* password */1]
+        };
 }
 
 var octetHeader = Axios.$$Headers[/* fromObj */0]({
@@ -46,93 +36,96 @@ function blankConfig(auth) {
         };
 }
 
-function content(cid) {
-  return $$await(Axios$1.get(url(baseURL, cid)));
+function ipfsURL(domain) {
+  return domain + "/ipfs";
 }
 
-function list(auth) {
-  return $$await(Axios$1.get(cidsURL, blankConfig(auth)));
+function cidsURL(domain) {
+  return domain + "/ipfs/cids";
 }
 
-function add(auth, content) {
-  return $$await(Axios$1.post(ipfsURL, content, octetConfig(auth)));
+function url(domain, cid) {
+  return domain + "/ipfs/" + cid;
 }
 
-function addStr(auth, _str) {
-  return $$await(Axios$1.post(ipfsURL, str, octetConfig(auth)));
+function content(base, cid) {
+  return $$await(Axios$1.get(url(base, cid)));
 }
 
-function pin(auth, cid) {
-  return $$await(Axios$1.put(url(baseURL, cid), { }, blankConfig(auth)));
+function list(base, auth) {
+  return $$await(Axios$1.get(base + "/ipfs/cids", blankConfig(auth)));
 }
 
-function remove(auth, cid) {
-  return $$await(Axios$1.delete(url(baseURL, cid), blankConfig(auth)));
+function add(base, auth, content) {
+  return $$await(Axios$1.post(base + "/ipfs", content, octetConfig(auth)));
 }
 
-function fissionUser(base, username, password) {
-  var user = /* record */[
-    /* username */username,
-    /* password */password
-  ];
+function addStr(base, auth, _str) {
+  return $$await(Axios$1.post(base + "/ipfs", str, octetConfig(auth)));
+}
+
+function pin(base, auth, cid) {
+  return $$await(Axios$1.put(url(base, cid), { }, blankConfig(auth)));
+}
+
+function remove(base, auth, cid) {
+  return $$await(Axios$1.delete(url(base, cid), blankConfig(auth)));
+}
+
+function create(base) {
   return /* record */[
           /* base */base,
+          /* url */(function (param) {
+              return url(base, param);
+            }),
+          /* content */(function (param) {
+              return content(base, param);
+            })
+        ];
+}
+
+var Simple = /* module */[/* create */create];
+
+function create$1(base, auth) {
+  return /* record */[
+          /* base */base,
+          /* url */(function (param) {
+              return url(base, param);
+            }),
+          /* content */(function (param) {
+              return content(base, param);
+            }),
           /* add */(function (param) {
-              return add(user, param);
+              return add(base, auth, param);
             }),
           /* addStr */(function (param) {
-              return addStr(user, param);
+              return addStr(base, auth, param);
             }),
-          /* content */content,
           /* pin */(function (param) {
-              return pin(user, param);
+              return pin(base, auth, param);
             }),
           /* remove */(function (param) {
-              return remove(user, param);
-            }),
-          /* url */(function (param) {
-              return url(base, param);
+              return remove(base, auth, param);
             })
         ];
 }
 
-function fission(base) {
-  return /* record */[
-          /* base */base,
-          /* login */(function (param, param$1) {
-              return fissionUser(base, param, param$1);
-            }),
-          /* content */content,
-          /* url */(function (param) {
-              return url(base, param);
-            })
-        ];
-}
+var User = /* module */[/* create */create$1];
 
-var instance = fission(baseURL);
-
-var env_username = "ca2c70bc13298c5109ee";
-
-var env_password = "VlBgonAFjZon2wd2VkTR3uc*p-XMd(L_Zf$nFvACpHQShqJ_Hp2Pa";
-
-exports.baseURL = baseURL;
-exports.ipfsURL = ipfsURL;
-exports.cidsURL = cidsURL;
-exports.env_username = env_username;
-exports.env_password = env_password;
-exports.convAuth = convAuth;
 exports.$$await = $$await;
-exports.url = url;
+exports.convAuth = convAuth;
 exports.octetHeader = octetHeader;
 exports.octetConfig = octetConfig;
 exports.blankConfig = blankConfig;
+exports.ipfsURL = ipfsURL;
+exports.cidsURL = cidsURL;
+exports.url = url;
 exports.content = content;
 exports.list = list;
 exports.add = add;
 exports.addStr = addStr;
 exports.pin = pin;
 exports.remove = remove;
-exports.fissionUser = fissionUser;
-exports.fission = fission;
-exports.instance = instance;
+exports.Simple = Simple;
+exports.User = User;
 /* octetHeader Not a pure module */

--- a/src/Fission.bs.js
+++ b/src/Fission.bs.js
@@ -96,6 +96,24 @@ remove("QmQbPPkak9itW3v8WSohtonCBiJcrnAUhrSW1TGPnmWe3f", user).then((function (r
         return Promise.resolve((console.log(error), /* () */0));
       }));
 
+function fission(base, auth) {
+  return /* record */[
+          /* base */base,
+          /* content */content,
+          /* url */(function (param) {
+              return url(base, param);
+            }),
+          /* pin */(function (cid) {
+              return pin(cid, auth);
+            })
+        ];
+}
+
+var me = /* record */[
+  /* age */5,
+  /* name */"Big Reason"
+];
+
 exports.baseURL = baseURL;
 exports.env_username = env_username;
 exports.env_password = env_password;
@@ -109,4 +127,6 @@ exports.addStr = addStr;
 exports.pin = pin;
 exports.remove = remove;
 exports.user = user;
+exports.me = me;
+exports.fission = fission;
 /* octetHeader Not a pure module */

--- a/src/Fission.bs.js
+++ b/src/Fission.bs.js
@@ -14,19 +14,19 @@ function url(domain, cid) {
   return domain + ("/ipfs/" + cid);
 }
 
+function convAuth(auth) {
+  return {
+          username: auth[/* username */0],
+          password: auth[/* password */1]
+        };
+}
+
 function handle(a) {
   return a.then((function (response) {
                   return Promise.resolve(response.data);
                 })).catch((function (prim) {
                 return Promise.resolve(prim);
               }));
-}
-
-function convAuth(auth) {
-  return {
-          username: auth[/* username */0],
-          password: auth[/* password */1]
-        };
 }
 
 var octetHeader = Axios.$$Headers[/* fromObj */0]({
@@ -118,11 +118,11 @@ var env_password = "VlBgonAFjZon2wd2VkTR3uc*p-XMd(L_Zf$nFvACpHQShqJ_Hp2Pa";
 exports.baseURL = baseURL;
 exports.ipfsURL = ipfsURL;
 exports.cidsURL = cidsURL;
-exports.url = url;
 exports.env_username = env_username;
 exports.env_password = env_password;
-exports.handle = handle;
+exports.url = url;
 exports.convAuth = convAuth;
+exports.handle = handle;
 exports.octetHeader = octetHeader;
 exports.octetConfig = octetConfig;
 exports.blankConfig = blankConfig;

--- a/src/Fission.bs.js
+++ b/src/Fission.bs.js
@@ -120,6 +120,8 @@ function fission(base) {
         ];
 }
 
+var instance = fission(baseURL);
+
 var env_username = "ca2c70bc13298c5109ee";
 
 var env_password = "VlBgonAFjZon2wd2VkTR3uc*p-XMd(L_Zf$nFvACpHQShqJ_Hp2Pa";
@@ -138,4 +140,5 @@ exports.pin = pin;
 exports.remove = remove;
 exports.fissionUser = fissionUser;
 exports.fission = fission;
+exports.instance = instance;
 /* octetHeader Not a pure module */

--- a/src/Fission.re
+++ b/src/Fission.re
@@ -1,115 +1,125 @@
-let baseURL = "http://localhost:1337";
-let env_username = "ca2c70bc13298c5109ee";
-let env_password = "VlBgonAFjZon2wd2VkTR3uc*p-XMd(L_Zf$nFvACpHQShqJ_Hp2Pa";
+  ///////////
+ // Types //
+///////////
 
 type cid = string;
+
 type auth = {
   username: string,
   password: string,
 };
 
-let octetHeader =
-  Axios.Headers.fromObj({"content-type": "application/octet-stream"});
+type fsnUser('a) = {
+  add:     Js.t('a) => Js.Promise.t(Js.Promise.error),
+  addStr:  cid      => Js.Promise.t(Js.Promise.error),
+  base:    string,
+  content: cid      => Js.Promise.t(Js.Promise.error),
+  pin:     cid      => Js.Promise.t(Js.Promise.error),
+  remove:  cid      => Js.Promise.t(Js.Promise.error),
+  url:     cid      => string
+};
+
+type fsn('a) = {
+  base:    string,
+  content: cid => Js.Promise.t(Js.Promise.error),
+  login:   (string, string) => fsnUser('a),
+  url:     cid => string
+};
+
+  ///////////////
+ // Constants //
+///////////////
+
+let baseURL = "http://localhost:1337";
+let ipfsURL = baseURL ++ "/ipfs";
+let cidsURL = ipfsURL ++ "/cids"
+
+let env_username = "ca2c70bc13298c5109ee";
+let env_password = "VlBgonAFjZon2wd2VkTR3uc*p-XMd(L_Zf$nFvACpHQShqJ_Hp2Pa";
+
+  ///////////////
+ // Functions //
+///////////////
+
+// Helpers
+
+let url = (domain: string, cid: cid) => domain ++ "/ipfs/" ++ cid;
 
 let convAuth = (auth: auth) => {
   "username": auth.username,
   "password": auth.password,
 };
 
-let url = (baseURL: string, cid: cid) => baseURL ++ "/ipfs/" ++ cid;
+let handle = a =>
+  a
+|> Js.Promise.then_(response => Js.Promise.resolve(response##data))
+|> Js.Promise.catch(Js.Promise.resolve);
+
+
+let octetHeader = Axios.Headers.fromObj({"content-type": "application/octet-stream"});
+let octetConfig = auth => Axios.makeConfig(~auth=convAuth(auth), ~headers=octetHeader, ());
+let blankConfig = auth => Axios.makeConfig(~auth=convAuth(auth), ());
+
+// Main Show
 
 let content = (cid: cid) =>
-  Js.Promise.(
-    Axios.get(url(baseURL, cid))
-    |> then_(response => resolve(response##data))
-    |> catch(error => resolve(error))
-  );
+  baseURL
+  -> url(cid)
+  -> Axios.get
+  -> handle
 
 let list = (auth: auth) =>
-  Js.Promise.(
-    Axios.getc(
-      baseURL ++ "/ipfs/cids",
-      Axios.makeConfig(~auth=convAuth(auth), ()),
-    )
-    |> then_(response => resolve(response##data))
-    |> catch(error => resolve(error))
-  );
+  cidsURL
+  -> Axios.getc(blankConfig(auth))
+  -> handle
 
 let add = (auth: auth, content: 'a) =>
-  Js.Promise.(
-    Axios.postDatac(
-      baseURL ++ "/ipfs/",
-      content,
-      Axios.makeConfig(~auth=convAuth(auth), ~headers=octetHeader, ()),
-    )
-    |> then_(response => resolve(response##data))
-    |> catch(error => resolve(error))
-  );
+  ipfsURL
+  -> Axios.postDatac(content, octetConfig(auth))
+  -> handle
 
 let addStr = (auth: auth, _str: string) =>
-  Js.Promise.(
-    Axios.postDatac(
-      baseURL ++ "/ipfs/",
-      [%bs.raw {|str|}],
-      Axios.makeConfig(~auth=convAuth(auth), ~headers=octetHeader, ()),
-    )
-    |> then_(response => resolve(response##data))
-    |> catch(error => resolve(error))
-  );
+  ipfsURL
+  -> Axios.postDatac([%bs.raw {|str|}], octetConfig(auth))
+  -> handle
 
 let pin = (auth: auth, cid: cid) =>
-  Js.Promise.(
-    Axios.putDatac(
-      url(baseURL, cid),
-      [%bs.raw {|{}|}],
-      Axios.makeConfig(~auth=convAuth(auth), ()),
-    )
-    |> then_(response => resolve(response##data))
-    |> catch(error => resolve(error))
-  );
+  baseURL
+  -> url(cid)
+  -> Axios.putDatac([%bs.raw {|{}|}], blankConfig(auth))
+  -> handle
 
 let remove = (auth: auth, cid: cid) =>
-  Js.Promise.(
-    Axios.deletec(
-      url(baseURL, cid),
-      Axios.makeConfig(~auth=convAuth(auth), ()),
-    )
-    |> then_(response => resolve(response##data))
-    |> catch(error => resolve(error))
-  );
+  baseURL
+  -> url(cid)
+  -> Axios.deletec(blankConfig(auth))
+  -> handle
 
-type fsnUser('a) = {
-  base: string,
-  content: cid => Js.Promise.t(Js.Promise.error),
-  url: cid => string,
-  add: Js.t('a) => Js.Promise.t(Js.Promise.error),
-  addStr: cid => Js.Promise.t(Js.Promise.error),
-  pin: cid => Js.Promise.t(Js.Promise.error),
-  remove: cid => Js.Promise.t(Js.Promise.error),
-};
-
-type fsn('a) = {
-  base: string,
-  content: cid => Js.Promise.t(Js.Promise.error),
-  url: cid => string,
-  login: (string, string) => fsnUser('a),
-};
+  /////////////
+ // Records //
+/////////////
 
 let fissionUser = (base, username, password) => {
   let user = {username, password};
+
   {
     base,
     content,
-    url: url(base),
-    add: add(user),
+    add:    add(user),
     addStr: addStr(user),
-    pin: pin(user),
+    pin:    pin(user),
     remove: remove(user),
+    url:    url(base)
   };
 };
 
 let fission = base => {
-  {base, content, url: url(base), login: fissionUser(base)};
+  {
+    base,
+    content,
+    login: fissionUser(base),
+    url:   url(base)
+  };
 };
 
-let instance = fission(baseURL);
+let instance: fsn(string) = fission(baseURL);

--- a/src/Fission.re
+++ b/src/Fission.re
@@ -52,9 +52,8 @@ let convAuth = (auth: auth) => {
 
 let handle = a =>
   a
-|> Js.Promise.then_(response => Js.Promise.resolve(response##data))
-|> Js.Promise.catch(Js.Promise.resolve);
-
+  |> Js.Promise.then_(response => Js.Promise.resolve(response##data))
+  |> Js.Promise.catch(Js.Promise.resolve);
 
 let octetHeader = Axios.Headers.fromObj({"content-type": "application/octet-stream"});
 let octetConfig = auth => Axios.makeConfig(~auth=convAuth(auth), ~headers=octetHeader, ());
@@ -62,34 +61,34 @@ let blankConfig = auth => Axios.makeConfig(~auth=convAuth(auth), ());
 
 // Main Show
 
-let content = (cid: cid) =>
+let content = cid =>
   baseURL
   -> url(cid)
   -> Axios.get
   -> handle
 
-let list = (auth: auth) =>
+let list = auth =>
   cidsURL
   -> Axios.getc(blankConfig(auth))
   -> handle
 
-let add = (auth: auth, content: 'a) =>
+let add = (auth, content) =>
   ipfsURL
   -> Axios.postDatac(content, octetConfig(auth))
   -> handle
 
-let addStr = (auth: auth, _str: string) =>
+let addStr = (auth, _str) =>
   ipfsURL
   -> Axios.postDatac([%bs.raw {|str|}], octetConfig(auth))
   -> handle
 
-let pin = (auth: auth, cid: cid) =>
+let pin = (auth, cid) =>
   baseURL
   -> url(cid)
   -> Axios.putDatac([%bs.raw {|{}|}], blankConfig(auth))
   -> handle
 
-let remove = (auth: auth, cid: cid) =>
+let remove = (auth, cid) =>
   baseURL
   -> url(cid)
   -> Axios.deletec(blankConfig(auth))

--- a/src/Fission.re
+++ b/src/Fission.re
@@ -2,6 +2,7 @@ let baseURL = "http://localhost:1337";
 let env_username = "ca2c70bc13298c5109ee";
 let env_password = "VlBgonAFjZon2wd2VkTR3uc*p-XMd(L_Zf$nFvACpHQShqJ_Hp2Pa";
 
+
 type cid = string;
 type auth = {
   username: string,
@@ -85,3 +86,37 @@ Js.Promise.(
   |> then_(result => resolve(Js.Console.log(result)))
   |> catch(error => resolve(Js.Console.log(error)))
 );
+
+type person = {
+  age: int,
+  name: string
+};
+
+let me = {
+  age: 5,
+  name: "Big Reason"
+};
+
+/* module Foo = { */
+/*   let */
+/* } */
+
+/* val foo: (int -> int) //= (a: int) => a + 1 */
+
+/* type foo = (f: (int): int, i: int): int; */
+
+type fsn = {
+  base: string,
+  content: cid => Js.Promise.t(Js.Promise.error),
+  url: cid => string,
+  pin: cid => Js.Promise.t(Js.Promise.error)
+};
+
+let fission = (base: string, auth: auth) => {
+  {
+    base,
+    content,
+    url: url(base),
+    pin: (cid: cid) => pin(cid, auth)
+  }
+}

--- a/src/Fission.re
+++ b/src/Fission.re
@@ -97,14 +97,6 @@ let me = {
   name: "Big Reason"
 };
 
-/* module Foo = { */
-/*   let */
-/* } */
-
-/* val foo: (int -> int) //= (a: int) => a + 1 */
-
-/* type foo = (f: (int): int, i: int): int; */
-
 type fsn = {
   base: string,
   content: cid => Js.Promise.t(Js.Promise.error),

--- a/src/Fission.re
+++ b/src/Fission.re
@@ -45,7 +45,7 @@ let await = promise =>
   |> Js.Promise.then_(response => Js.Promise.resolve(response##data))
   |> Js.Promise.catch(Js.Promise.resolve);
 
-let url = (domain: string, cid: cid) => domain ++ "/ipfs/" ++ cid;
+let url = (domain, cid) => domain ++ "/ipfs/" ++ cid;
 let octetHeader = Axios.Headers.fromObj({"content-type": "application/octet-stream"});
 let octetConfig = auth => Axios.makeConfig(~auth=convAuth(auth), ~headers=octetHeader, ());
 let blankConfig = auth => Axios.makeConfig(~auth=convAuth(auth), ());

--- a/src/Fission.re
+++ b/src/Fission.re
@@ -104,7 +104,7 @@ type fsn = {
   pin: cid => Js.Promise.t(Js.Promise.error)
 };
 
-let fission = (base: string, auth: auth) => {
+let fission = (base: string, auth: auth): fsn => {
   {
     base,
     content,

--- a/src/Fission.re
+++ b/src/Fission.re
@@ -45,7 +45,7 @@ let env_password = "VlBgonAFjZon2wd2VkTR3uc*p-XMd(L_Zf$nFvACpHQShqJ_Hp2Pa";
 
 let url = (domain: string, cid: cid) => domain ++ "/ipfs/" ++ cid;
 
-let convAuth = (auth: auth) => {
+let convAuth = auth => {
   "username": auth.username,
   "password": auth.password,
 };

--- a/src/Fission.re
+++ b/src/Fission.re
@@ -85,7 +85,7 @@ let addStr = (auth, _str) =>
 let pin = (auth, cid) =>
   baseURL
   -> url(cid)
-  -> Axios.putDatac([%bs.raw {|{}|}], blankConfig(auth))
+  -> Axios.putDatac(Js.Obj.empty(), blankConfig(auth))
   -> handle
 
 let remove = (auth, cid) =>

--- a/src/Fission.re
+++ b/src/Fission.re
@@ -95,8 +95,7 @@ type fsn('a) = {
   login: (string, string) => fsnUser('a),
 };
 
-let fissionUser =
-    (base: string, username: string, password: string): fsnUser('a) => {
+let fissionUser = (base, username, password) => {
   let user = {username, password};
   {
     base,
@@ -109,7 +108,7 @@ let fissionUser =
   };
 };
 
-let fission = (base: string): fsn('a) => {
+let fission = base => {
   {base, content, url: url(base), login: fissionUser(base)};
 };
 

--- a/src/Fission.re
+++ b/src/Fission.re
@@ -55,7 +55,7 @@ let remove = (base, auth, cid) =>
   -> Axios.deletec(blankConfig(auth))
   -> await
 
-// Records
+// Modules
 
 module Simple {
   type t = {


### PR DESCRIPTION
# Problem
- types are too tight especially around `fissionUser.add`
- repetitive code around promises
- confusing/non-idiomatic structure around user vs simple methods

# Solution
- less type annotations
- `await` helper function for promises
- kept methods in main module but added two submodules `Simple` and `User` with constructors for repeated calls

PR builds off of unmerged PRs:
- https://github.com/fission-suite/reasonml-client/pull/1 
- https://github.com/fission-suite/reasonml-client/pull/2 